### PR TITLE
[8.x] fix: VerifyCsrfToken - http_only config

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -190,8 +190,15 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+                'XSRF-TOKEN', 
+                $request->session()->token(), 
+                $this->availableAt(60 * $config['lifetime']),
+                $config['path'], 
+                $config['domain'], 
+                $config['secure'], 
+                $config['http_only'], 
+                false, 
+                $config['same_site'] ?? null
             )
         );
 


### PR DESCRIPTION
VerifyCsrfToken - newCookie() is did not used the session config "http_only" value.

Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php:183